### PR TITLE
Refactor carrinho hook to use dispatch actions

### DIFF
--- a/src/hooks/useCarrinhoContext.js
+++ b/src/hooks/useCarrinhoContext.js
@@ -1,69 +1,52 @@
+import { useContext } from "react";
+import { CarrinhoContext } from '@/context/CarrinhoContext';
+import { ADD_PRODUTO, REMOVE_PRODUTO, UPDATE_QUANTIDADE } from "../reduces/carrinhoReducer";
 
--import { useContext, useEffect, useMemo } from "react";
-+import { useContext } from "react";
- import { CarrinhoContext } from '@/context/CarrinhoContext';
- import { ADD_PRODUTO, REMOVE_PRODUTO, UPDATE_QUANTIDADE } from "../reduces/carrinhoReducer";
- 
- const addProdutoAction = (novoProduto) => ({
-     type: ADD_PRODUTO,
-     payload: novoProduto,
- });
- 
- const removeProdutoAction = (produtoId) => ({
-     type: REMOVE_PRODUTO,
-     payload: produtoId,
-   });
-   
-   const updateQuantidadeAction = (produtoId, quantidade) => ({
-     type: UPDATE_QUANTIDADE,
-     payload: { produtoId, quantidade },
-   });
-   
- 
- export const useCarrinhoContext = () => {
-     const { carrinho, dispatch, quantidade, valorTotal } =
-         useContext(CarrinhoContext);
- 
-   
- 
-     function adicionarProduto(novoProduto) {
-         dispatch(addProdutoAction(novoProduto))
-     }
- 
-     function removerProduto(id) {
-         const produto = carrinho.find((itemDoCarrinho) => itemDoCarrinho.id === id);
--        const ehOUltimo = produto.quantidade === 1;
--        if (ehOUltimo) {
--            return setCarrinho((carrinhoAnterior) =>
--                carrinhoAnterior.filter((itemDoCarrinho) => itemDoCarrinho.id !== id)
--            );
--        }
--
--        const carrinhoAtualzado = mudarQuantidade(id, -1)
-+        if (!produto) return;
- 
--        setCarrinho([...carrinhoAtualzado])
-+        if (produto.quantidade <= 1) {
-+            dispatch(removeProdutoAction(id));
-+        } else {
-+            dispatch(updateQuantidadeAction(id, produto.quantidade - 1));
-+        }
-     }
- 
-     function removerProdutoCarrinho(id) {
--        const produto = carrinho.filter((itemDoCarrinho) => itemDoCarrinho.id !== id);
--        setCarrinho(produto);
-+        dispatch(removeProdutoAction(id));
-     }
- 
-     return {
-         carrinho,
-         adicionarProduto,
-         removerProduto,
-         removerProdutoCarrinho,
-         valorTotal,
-         quantidade,
-     };
- 
--}
-+}
+const addProdutoAction = (novoProduto) => ({
+    type: ADD_PRODUTO,
+    payload: novoProduto,
+});
+
+const removeProdutoAction = (produtoId) => ({
+    type: REMOVE_PRODUTO,
+    payload: produtoId,
+});
+
+const updateQuantidadeAction = (produtoId, quantidade) => ({
+    type: UPDATE_QUANTIDADE,
+    payload: { produtoId, quantidade },
+});
+
+export const useCarrinhoContext = () => {
+    const { carrinho, dispatch, quantidade, valorTotal } =
+        useContext(CarrinhoContext);
+
+    function adicionarProduto(novoProduto) {
+        dispatch(addProdutoAction(novoProduto));
+    }
+
+    function removerProduto(id) {
+        const produto = carrinho.find((itemDoCarrinho) => itemDoCarrinho.id === id);
+        if (!produto) return;
+
+        if (produto.quantidade <= 1) {
+            dispatch(removeProdutoAction(id));
+        } else {
+            dispatch(updateQuantidadeAction(id, produto.quantidade - 1));
+        }
+    }
+
+    function removerProdutoCarrinho(id) {
+        dispatch(removeProdutoAction(id));
+    }
+
+    return {
+        carrinho,
+        adicionarProduto,
+        removerProduto,
+        removerProdutoCarrinho,
+        valorTotal,
+        quantidade,
+    };
+};
+


### PR DESCRIPTION
## Summary
- clean up diff markers and restore useCarrinhoContext hook
- ensure carrinho actions only dispatch reducer events

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: disabled is not defined in .eslintrc.cjs)


------
https://chatgpt.com/codex/tasks/task_e_6896063697c88328ac713c8994cd4248