### PR TITLE
Render empty cart message as list item

### DIFF
--- a/src/components/ListaProdutosCarrinho/index.jsx
+++ b/src/components/ListaProdutosCarrinho/index.jsx
@@ -8,7 +8,7 @@ const ListaProdutosCarrinho = ({ carrinho }) => {
   return (
     <ul className="list-unstyled">
       {carrinho.length === 0 ? (
-        <p className="text-center my-5">Não há produtos no carrinho</p>
+        <li className="text-center my-5">Não há produtos no carrinho</li>
       ) : (
         carrinho.map((itemCarrinho) => {
           return location.pathname === "/carrinho" ? (


### PR DESCRIPTION
## Summary
- replace empty cart paragraph with styled list item so list contains only `<li>` elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: disabled is not defined in `.eslintrc.cjs`)*

------
https://chatgpt.com/codex/tasks/task_e_68960632587c8328a8b99d7cc01c7eab