### PR TITLE
Persistir carrinho no localStorage

### DIFF
--- a/src/context/CarrinhoContext.jsx
+++ b/src/context/CarrinhoContext.jsx
@@ -1,44 +1,63 @@
+import { createContext, useEffect, useMemo, useReducer, useState } from "react";
+import { carrinhoReducer, LIMPAR_CARRINHO } from "../reduces/carrinhoReducer";
 
- import { createContext, useEffect, useMemo, useReducer, useState } from "react";
- import { carrinhoReducer } from "../reduces/carrinhoReducer";
- 
- export const CarrinhoContext = createContext();
- CarrinhoContext.displayName = "Carrinho"
- 
- const estadoInicial = [];
- 
- export const CarrinhoProvider = ( {children} ) => {
-     const [carrinho, dispatch] = useReducer(carrinhoReducer, estadoInicial)
-     const [quantidade, setQuantidade] = useState(0)
-     const [valorTotal, setValorTotal] = useState(0)
- 
-     const { totalTemp, quantidadeTemp } = useMemo(() => {
-         return carrinho.reduce((acumulador, produto) => ({
-             quantidadeTemp: acumulador.quantidadeTemp + produto.quantidade,
-             totalTemp: acumulador.totalTemp + produto.preco * produto.quantidade,
-         }), {
-             quantidadeTemp: 0,
-             totalTemp: 0,
-         }
-         );
-     }, [carrinho])
- 
-     useEffect(() => {
--
-         setQuantidade(quantidadeTemp);
-         setValorTotal(totalTemp);
--    });
-+    }, [quantidadeTemp, totalTemp]);
- 
-     return (
-         <CarrinhoContext.Provider value={{
-             carrinho, 
-             dispatch, 
-             quantidade,
-             valorTotal
-             }}
-         >
-             {children}
-         </CarrinhoContext.Provider>
-     )
- }
+export const CarrinhoContext = createContext();
+CarrinhoContext.displayName = "Carrinho";
+
+const estadoInicial = [];
+
+export const CarrinhoProvider = ({ children }) => {
+  const [carrinho, dispatch] = useReducer(
+    carrinhoReducer,
+    estadoInicial,
+    () => {
+      const carrinhoLocalStorage = localStorage.getItem("carrinho");
+      return carrinhoLocalStorage
+        ? JSON.parse(carrinhoLocalStorage)
+        : estadoInicial;
+    }
+  );
+  const [quantidade, setQuantidade] = useState(0);
+  const [valorTotal, setValorTotal] = useState(0);
+
+  const { totalTemp, quantidadeTemp } = useMemo(() => {
+    return carrinho.reduce(
+      (acumulador, produto) => ({
+        quantidadeTemp: acumulador.quantidadeTemp + produto.quantidade,
+        totalTemp: acumulador.totalTemp + produto.preco * produto.quantidade,
+      }),
+      {
+        quantidadeTemp: 0,
+        totalTemp: 0,
+      }
+    );
+  }, [carrinho]);
+
+  useEffect(() => {
+    setQuantidade(quantidadeTemp);
+    setValorTotal(totalTemp);
+  }, [quantidadeTemp, totalTemp]);
+
+  useEffect(() => {
+    localStorage.setItem("carrinho", JSON.stringify(carrinho));
+  }, [carrinho]);
+
+  const limparCarrinho = () => {
+    dispatch({ type: LIMPAR_CARRINHO });
+    localStorage.removeItem("carrinho");
+  };
+
+  return (
+    <CarrinhoContext.Provider
+      value={{
+        carrinho,
+        dispatch,
+        quantidade,
+        valorTotal,
+        limparCarrinho,
+      }}
+    >
+      {children}
+    </CarrinhoContext.Provider>
+  );
+};

--- a/src/reduces/carrinhoReducer.js
+++ b/src/reduces/carrinhoReducer.js
@@ -1,38 +1,38 @@
+export const ADD_PRODUTO = "ADD_PRODUTO";
+export const REMOVE_PRODUTO = "REMOVE_PRODUTO";
+export const UPDATE_QUANTIDADE = "UPDATE_QUANTIDADE";
+export const LIMPAR_CARRINHO = "LIMPAR_CARRINHO";
 
- export const ADD_PRODUTO = "ADD_PRODUTO";
- export const REMOVE_PRODUTO = "REMOVE_PRODUTO";
- export const UPDATE_QUANTIDADE = "UPDATE_QUANTIDADE";
- 
- export const carrinhoReducer = (state, action) => {
-     switch (action.type) {
-         case ADD_PRODUTO:
-             const novoProduto = action.payload
-             const produto = state.findIndex((item) => item.id === novoProduto.id);
-             if (produto === -1) {
--                novoProduto.quantidade = 1;
--                return [...state, novoProduto];
-+                const produtoComQuantidade = { ...novoProduto, quantidade: 1 };
-+                return [...state, produtoComQuantidade];
-             } else {
-                 return state.map((item, index) =>
-                     index === produto
-                         ? { ...item, quantidade: item.quantidade + 1 }
-                         : item
-                 );
-             }
-         case REMOVE_PRODUTO:
-             const produtoId = action.payload;
-             return state.filter((item) => item.id !== produtoId);
- 
-         case UPDATE_QUANTIDADE:
-             const { produtoId: id, quantidade } = action.payload;
-             return state.map((item) =>
-                 item.id === id ? { ...item, quantidade } : item
-             );
- 
-         default:
-             return state;
- 
-     }
--};
-+};
+export const carrinhoReducer = (state, action) => {
+  switch (action.type) {
+    case ADD_PRODUTO: {
+      const novoProduto = action.payload;
+      const produtoIndex = state.findIndex(
+        (item) => item.id === novoProduto.id
+      );
+      if (produtoIndex === -1) {
+        const produtoComQuantidade = { ...novoProduto, quantidade: 1 };
+        return [...state, produtoComQuantidade];
+      }
+      return state.map((item, index) =>
+        index === produtoIndex
+          ? { ...item, quantidade: item.quantidade + 1 }
+          : item
+      );
+    }
+    case REMOVE_PRODUTO: {
+      const produtoId = action.payload;
+      return state.filter((item) => item.id !== produtoId);
+    }
+    case UPDATE_QUANTIDADE: {
+      const { produtoId: id, quantidade } = action.payload;
+      return state.map((item) =>
+        item.id === id ? { ...item, quantidade } : item
+      );
+    }
+    case LIMPAR_CARRINHO:
+      return [];
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
## Summary
- Inicializa carrinho com dados salvos no `localStorage`
- Sincroniza o `localStorage` sempre que o carrinho muda
- Disponibiliza função para limpar carrinho e `localStorage`

## Testing
- `npm run lint` *(fails: disabled is not defined in .eslintrc.cjs)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689606304a308328b7380e8507b1d49a