### PR TITLE
fix: update cart totals on change

### DIFF
--- a/src/context/CarrinhoContext.jsx
+++ b/src/context/CarrinhoContext.jsx
@@ -24,10 +24,9 @@ export const CarrinhoProvider = ( {children} ) => {
     }, [carrinho])
 
     useEffect(() => {
-
         setQuantidade(quantidadeTemp);
         setValorTotal(totalTemp);
-    });
+    }, [quantidadeTemp, totalTemp]);
 
     return (
         <CarrinhoContext.Provider value={{


### PR DESCRIPTION
## Summary
- ensure cart totals update only when computed values change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: disabled is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6896015c160c83289dd7fe8c21cadc9e