### PR TITLE
refactor: use handleClick prop for Botao

### DIFF
--- a/src/components/CarrinhoSuspenso/ItemCarrinhoSuspenso/index.jsx
+++ b/src/components/CarrinhoSuspenso/ItemCarrinhoSuspenso/index.jsx
@@ -28,7 +28,7 @@ const ItemCarrinhoSuspenso = ({itemCarrinho}) => {
           <Botao
             variant="deleteItem"
             aria-label="Excluir"
-            onClick={() => removerProdutoCarrinho(itemCarrinho.id)}
+            handleClick={() => removerProdutoCarrinho(itemCarrinho.id)}
           >
             delete_forever
           </Botao>

--- a/src/components/CarrinhoSuspenso/TotalCarrinho/index.jsx
+++ b/src/components/CarrinhoSuspenso/TotalCarrinho/index.jsx
@@ -14,7 +14,7 @@ const TotalCarrinho = ({ valorTotalCarrinho }) => {
       </div>
       <div className="d-flex flex-column flex-md-row gap-2 mx-1 mx-lg-0 justify-content-between justify-content-md-evelyn">
         <Botao
-          onClick={() => navigate("/carrinho")}
+          handleClick={() => navigate("/carrinho")}
           variant="primary"
           className="border-0 w-100"
         >

--- a/src/components/Sumario/index.jsx
+++ b/src/components/Sumario/index.jsx
@@ -13,7 +13,7 @@ const Sumario = () => {
         <Botao
           variant="tertiary"
           aria-label="Continuar comprando"
-          onClick={() => navigate("/")}
+          handleClick={() => navigate("/")}
         >
           Continuar comprando
         </Botao>


### PR DESCRIPTION
## Summary
- update Botao usages to use handleClick instead of onClick
- ensure consistency across cart-related components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ReferenceError: disabled is not defined)

------
https://chatgpt.com/codex/tasks/task_e_68960158b4508328817624608e5b25cc