### PR TITLE
fix justify-content-md-evenly class name

### DIFF
--- a/src/components/CarrinhoSuspenso/TotalCarrinho/index.jsx
+++ b/src/components/CarrinhoSuspenso/TotalCarrinho/index.jsx
@@ -12,7 +12,7 @@ const TotalCarrinho = ({ valorTotalCarrinho }) => {
         <p className="verde-limao m-0">Total</p>
         <ValorFormatado valor={valorTotalCarrinho} />
       </div>
-      <div className="d-flex flex-column flex-md-row gap-2 mx-1 mx-lg-0 justify-content-between justify-content-md-evelyn">
+      <div className="d-flex flex-column flex-md-row gap-2 mx-1 mx-lg-0 justify-content-between justify-content-md-evenly">
         <Botao
           onClick={() => navigate("/carrinho")}
           variant="primary"

--- a/src/components/Sumario/index.jsx
+++ b/src/components/Sumario/index.jsx
@@ -9,7 +9,7 @@ const Sumario = () => {
   return (
     <div className="d-flex flex-column gap-3 sumario">
       <ResumoCompra />
-      <div className="d-flex flex-column flex-md-row gap-2 mx-1 mx-lg-0 justify-content-between justify-content-md-evelyn">
+      <div className="d-flex flex-column flex-md-row gap-2 mx-1 mx-lg-0 justify-content-between justify-content-md-evenly">
         <Botao
           variant="tertiary"
           aria-label="Continuar comprando"


### PR DESCRIPTION
## Summary
- fix typo in Cart and Summary components, using `justify-content-md-evenly`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ReferenceError: disabled is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68960155fcdc832881b451061e16a0fb