### PR TITLE
fix: replace class with className in error page

### DIFF
--- a/src/pages/PaginaErro.jsx
+++ b/src/pages/PaginaErro.jsx
@@ -5,14 +5,14 @@ const PaginaErro = () => {
   return (
     <>
       <BarraNavegacao />
-      <div class="d-flex align-items-center justify-content-center vh-100">
-        <div class="text-center">
-          <h1 class="display-1 fw-bold">404</h1>
-          <p class="fs-3">Ops! Página não encontrada</p>
-          <p class="lead">
+      <div className="d-flex align-items-center justify-content-center vh-100">
+        <div className="text-center">
+          <h1 className="display-1 fw-bold">404</h1>
+          <p className="fs-3">Ops! Página não encontrada</p>
+          <p className="lead">
             A página que você está procurando não existe ainda.
           </p>
-          <Link to={`/`} class="btn btn-primary">
+          <Link to={`/`} className="btn btn-primary">
             Ir para Home
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- use `className` for all elements in `PaginaErro`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: disabled is not defined in ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68960153cff083289def02057208bd22