### PR TITLE
fix: default empty className for Botao

### DIFF
--- a/src/components/Botao/index.jsx
+++ b/src/components/Botao/index.jsx
@@ -4,7 +4,7 @@ const Botao = ({
   type,
   children,
   variant = "default",
-  className,
+  className = "",
   handleClick,
   ...rest
 }) => {


### PR DESCRIPTION
## Summary
- avoid `undefined` in `<Botao>` when no class is provided

## Testing
- `node -e "require('@babel/register')({presets: ['@babel/preset-react']}); const React=require('react'); const {renderToStaticMarkup} = require('react-dom/server'); const Botao=require('./src/components/Botao').default; const html=renderToStaticMarkup(React.createElement(Botao, {variant: 'default'}, 'Click')); console.log(html); console.log('contains undefined:', html.includes('undefined'));"`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: disabled is not defined in .eslintrc.cjs)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689601408cb8832889afc1d67f6fd6bf