### PR TITLE
Fix Botao component className default and structure

### DIFF
--- a/src/components/Botao/index.jsx
+++ b/src/components/Botao/index.jsx
@@ -1,33 +1,37 @@
- import React from "react";
- 
- const Botao = ({
-   type,
-   children,
-   variant = "default",
--  className,
-+  className = "",
-   handleClick,
-   ...rest
- }) => {
-   const buttonStyleMap = {
-     default: "btn rounded-0 btn-outline-light",
-     primary: "btn rounded-0 btn-dark botao-lilas",
-     secondary: "btn rounded-0 btn-outline-purple",
-     tertiary: "btn rounded-0 btn-tertiary btn-dark",
-     addItem:
-       "botao__circular bg-transparent border-light text-light rounded-circle",
-     removeItem:
-       "botao__circular border bg-transparent border-light text-light rounded-circle",
-     deleteItem:
-       "botao__excluir text-light fw-semibol material-symbols-outlined",
-     close: "btn-close btn-close-white",
-   };
- 
-   return (
-     <button
-       className={`${buttonStyleMap[variant]} ${className}`}
-       type={type}
-       onClick={handleClick}
-       {...rest}
-     >
-       {children}
+import React from "react";
+
+const Botao = ({
+  type,
+  children,
+  variant = "default",
+  className = "",
+  handleClick,
+  ...rest
+}) => {
+  const buttonStyleMap = {
+    default: "btn rounded-0 btn-outline-light",
+    primary: "btn rounded-0 btn-dark botao-lilas",
+    secondary: "btn rounded-0 btn-outline-purple",
+    tertiary: "btn rounded-0 btn-tertiary btn-dark",
+    addItem:
+      "botao__circular bg-transparent border-light text-light rounded-circle",
+    removeItem:
+      "botao__circular border bg-transparent border-light text-light rounded-circle",
+    deleteItem:
+      "botao__excluir text-light fw-semibol material-symbols-outlined",
+    close: "btn-close btn-close-white",
+  };
+
+  return (
+    <button
+      className={`${buttonStyleMap[variant]} ${className}`}
+      type={type}
+      onClick={handleClick}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Botao;


### PR DESCRIPTION
## Summary
- fix Botao component className prop default to empty string
- add missing closing button tag and export

## Testing
- `npm run lint` *(fails: ReferenceError disabled is not defined in .eslintrc.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68960c0c88c883288316fc9dd217e04c