### PR TITLE
fix: use className in error page

### DIFF
--- a/src/pages/PaginaErro.jsx
+++ b/src/pages/PaginaErro.jsx
@@ -1,30 +1,24 @@
- import { Link } from "react-router-dom";
- import BarraNavegacao from "@/components/BarraNavegacao";
- 
- const PaginaErro = () => {
-   return (
-     <>
-       <BarraNavegacao />
--      <div class="d-flex align-items-center justify-content-center vh-100">
--        <div class="text-center">
--          <h1 class="display-1 fw-bold">404</h1>
--          <p class="fs-3">Ops! Página não encontrada</p>
--          <p class="lead">
-+      <div className="d-flex align-items-center justify-content-center vh-100">
-+        <div className="text-center">
-+          <h1 className="display-1 fw-bold">404</h1>
-+          <p className="fs-3">Ops! Página não encontrada</p>
-+          <p className="lead">
-             A página que você está procurando não existe ainda.
-           </p>
--          <Link to={`/`} class="btn btn-primary">
-+          <Link to={`/`} className="btn btn-primary">
-             Ir para Home
-           </Link>
-         </div>
-       </div>
-     </>
-   );
- };
- 
- export default PaginaErro;
+import { Link } from "react-router-dom";
+import BarraNavegacao from "@/components/BarraNavegacao";
+
+const PaginaErro = () => {
+  return (
+    <>
+      <BarraNavegacao />
+      <div className="d-flex align-items-center justify-content-center vh-100">
+        <div className="text-center">
+          <h1 className="display-1 fw-bold">404</h1>
+          <p className="fs-3">Ops! Página não encontrada</p>
+          <p className="lead">
+            A página que você está procurando não existe ainda.
+          </p>
+          <Link to={`/`} className="btn btn-primary">
+            Ir para Home
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default PaginaErro;


### PR DESCRIPTION
## Summary
- clean up PaginaErro markup
- ensure className is used for React components

## Testing
- `npm run lint` *(fails: ReferenceError: disabled is not defined in .eslintrc.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68960c0f2ad88328999d918a68c1fad7