### PR TITLE
feat: add novidades page and new products

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Home from "./pages/Home";
 import Carrinho from "./pages/Carrinho";
 import PaginaErro from "./pages/PaginaErro";
+import Novidades from "./pages/Novidades";
 
 import "./App.css";
 import { CarrinhoProvider } from "./context/CarrinhoContext";
@@ -14,6 +15,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/carrinho" element={<Carrinho />} />
+          <Route path="/novidades" element={<Novidades />} />
           <Route path="*" element={<PaginaErro />} />
         </Routes>
       </CarrinhoProvider>

--- a/src/components/Produtos/Produto/index.jsx
+++ b/src/components/Produtos/Produto/index.jsx
@@ -9,6 +9,7 @@ const Produto = ({
   titulo,
   descricao,
   preco,
+  novo,
   adicionarProduto,
 }) => {
   return (
@@ -16,6 +17,9 @@ const Produto = ({
       <div className="card">
         <img className="img-fluid" src={src} alt={alt} />
         <div className="card-body">
+          {novo && (
+            <span className="badge text-bg-success mb-2">Novo</span>
+          )}
           <h5 className="card-title fw-bold">{titulo}</h5>
           <p className="card-text">{descricao}</p>
           <p className="fw-bold">{formatadorMoeda(preco)}</p>

--- a/src/components/ProdutosNovos/index.jsx
+++ b/src/components/ProdutosNovos/index.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Produto from "@/components/Produtos/Produto";
+import produtos from "@/mocks/produtos.json";
+import Titulo from "@/components/Titulo";
+import { useCarrinhoContext } from "@/hooks/useCarrinhoContext";
+
+const ProdutosNovos = () => {
+  const { adicionarProduto } = useCarrinhoContext();
+  const produtosNovos = produtos.filter((produto) => produto.novo);
+
+  return (
+    <section role="novidades" aria-label="Produtos recém chegados">
+      <Titulo>Novidades</Titulo>
+      <div className="container row mx-auto">
+        {produtosNovos.map((produto) => (
+          <Produto
+            key={produto.id}
+            {...produto}
+            adicionarProduto={adicionarProduto}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProdutosNovos;

--- a/src/mocks/produtos.json
+++ b/src/mocks/produtos.json
@@ -5,7 +5,8 @@
     "alt": "Modelo masculo vestindo touca preta, blusa marrom e calça jeans, com uma parede cinza de fundo.",
     "titulo": "Camiseta conforto",
     "descricao": "Multicores e tamanhos. Tecido de algodão 100% fresquinho.",
-    "preco": 70.0
+    "preco": 70.0,
+    "novo": false
   },
   {
     "id": 2,
@@ -13,7 +14,8 @@
     "alt": "Modelo feminina vestindo blusa marrom, calça bege, par de sapatos altos na cor branca, cordão e pulseira, em um ambiente aberto com chão de terra e matos secos.",
     "titulo": "Calça Alfaiataria",
     "descricao": "Modelo Wide Leg alfaiataria em linho. Uma peça para vida toda!",
-    "preco": 180.0
+    "preco": 180.0,
+    "novo": true
   },
   {
     "id": 3,
@@ -21,7 +23,8 @@
     "alt": "Foco nos pés de modelo usando par de tênis e meia na cor branca, e calça na cor preta, pisando em uma poça de água.",
     "titulo": "Tênis Chunky",
     "descricao": "Snicker casual com solado mais alto e modelagem robusta. Modelo unissex.",
-    "preco": 250.0
+    "preco": 250.0,
+    "novo": false
   },
   {
     "id": 4,
@@ -29,7 +32,8 @@
     "alt": "Modelo masculino vestindo toca e calça na cor preta, jaqueta jeans azul, blusa branca e cordão dourado, em um fundo branco.",
     "titulo": "Jaqueta Jeans",
     "descricao": "Modelo unissex oversized com gola de camurça. Atemporal e autêntica!",
-    "preco": 150.0
+    "preco": 150.0,
+    "novo": true
   },
   {
     "id": 5,
@@ -37,7 +41,8 @@
     "alt": "Modelo masculino com blusa branca e um par de óculos de lentes transparentes arredondadas, utilizando um notebook, com um cachorro poodle branco no seu colo, e em um fundo branco.",
     "titulo": "Óculos Redondo",
     "descricao": "Armação metálica em grafite com lentes arredondadas. Sem erro!",
-    "preco": 120.0
+    "preco": 120.0,
+    "novo": false
   },
   {
     "id": 6,
@@ -45,6 +50,7 @@
     "alt": "Cintura, pernas e pés de modelo feminina vestindo sobretudo de cor predominante bege com detalhes em tom vermelho e escuro, com calça e par de sapatos na cor preta, segurando bolsa na cor bege, com fundo de prédio.",
     "titulo": "Bolsa coringa",
     "descricao": "Bolsa camel em couro sintético de alta duração. Perfeita!",
-    "preco": 120.0
+    "preco": 120.0,
+    "novo": true
   }
 ]

--- a/src/pages/Novidades.jsx
+++ b/src/pages/Novidades.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import BarraNavegacao from "@/components/BarraNavegacao";
+import Rodape from "@/components/Rodape";
+import ProdutosNovos from "@/components/ProdutosNovos";
+import NovidadesNewsletter from "@/components/Novidades";
+
+const Novidades = () => {
+  return (
+    <>
+      <BarraNavegacao />
+      <ProdutosNovos />
+      <NovidadesNewsletter />
+      <Rodape />
+    </>
+  );
+};
+
+export default Novidades;


### PR DESCRIPTION
## Summary
- add novidades page to showcase newly released products
- display "Novo" badge and filter products marked as new
- expose novidades route and flag new items in mock data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: disabled is not defined in ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_689619e448f883288ac775d268b8e411