### PR TITLE
Add routes for store, promotion, and news pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Home from "./pages/Home";
 import Carrinho from "./pages/Carrinho";
+import Lojas from "./pages/Lojas";
+import Promocoes from "./pages/Promocoes";
+import Novidades from "./pages/Novidades";
 import PaginaErro from "./pages/PaginaErro";
 
 import "./App.css";
@@ -14,6 +17,9 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/carrinho" element={<Carrinho />} />
+          <Route path="/lojas" element={<Lojas />} />
+          <Route path="/promocoes" element={<Promocoes />} />
+          <Route path="/novidades" element={<Novidades />} />
           <Route path="*" element={<PaginaErro />} />
         </Routes>
       </CarrinhoProvider>

--- a/src/pages/Lojas.jsx
+++ b/src/pages/Lojas.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import BarraNavegacao from "@/components/BarraNavegacao";
+import CarrinhoSuspenso from "@/components/CarrinhoSuspenso";
+import Rodape from "@/components/Rodape";
+import Titulo from "@/components/Titulo";
+
+const Lojas = () => {
+  return (
+    <>
+      <BarraNavegacao />
+      <CarrinhoSuspenso />
+      <main>
+        <Titulo element="h1">Lojas</Titulo>
+      </main>
+      <Rodape />
+    </>
+  );
+};
+
+export default Lojas;
+

--- a/src/pages/Novidades.jsx
+++ b/src/pages/Novidades.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import BarraNavegacao from "@/components/BarraNavegacao";
+import CarrinhoSuspenso from "@/components/CarrinhoSuspenso";
+import Rodape from "@/components/Rodape";
+import NovidadesSection from "@/components/Novidades";
+
+const Novidades = () => {
+  return (
+    <>
+      <BarraNavegacao />
+      <CarrinhoSuspenso />
+      <main>
+        <NovidadesSection />
+      </main>
+      <Rodape />
+    </>
+  );
+};
+
+export default Novidades;
+

--- a/src/pages/Promocoes.jsx
+++ b/src/pages/Promocoes.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import BarraNavegacao from "@/components/BarraNavegacao";
+import CarrinhoSuspenso from "@/components/CarrinhoSuspenso";
+import Rodape from "@/components/Rodape";
+import Titulo from "@/components/Titulo";
+
+const Promocoes = () => {
+  return (
+    <>
+      <BarraNavegacao />
+      <CarrinhoSuspenso />
+      <main>
+        <Titulo element="h1">Promoções</Titulo>
+      </main>
+      <Rodape />
+    </>
+  );
+};
+
+export default Promocoes;
+


### PR DESCRIPTION
## Summary
- Import new Lojas, Promocoes, and Novidades pages and register routes
- Provide placeholder pages that reuse navigation, cart overlay, and footer components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ReferenceError disabled is not defined in ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689619e89c048328a772c8734bc38728