### PR TITLE
feat: add promotion and new product filters

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,6 @@ module.exports = {
       "warn",
       { allowConstantExport: true },
     ],
-    "react/prop-types": disabled,
+    "react/prop-types": "off",
   },
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Home from "./pages/Home";
 import Carrinho from "./pages/Carrinho";
 import PaginaErro from "./pages/PaginaErro";
+import Promocoes from "./pages/Promocoes";
+import Novidades from "./pages/Novidades";
 
 import "./App.css";
 import { CarrinhoProvider } from "./context/CarrinhoContext";
@@ -14,6 +16,8 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/carrinho" element={<Carrinho />} />
+          <Route path="/promocoes" element={<Promocoes />} />
+          <Route path="/novidades" element={<Novidades />} />
           <Route path="*" element={<PaginaErro />} />
         </Routes>
       </CarrinhoProvider>

--- a/src/components/Produtos/Produto/index.jsx
+++ b/src/components/Produtos/Produto/index.jsx
@@ -9,6 +9,9 @@ const Produto = ({
   titulo,
   descricao,
   preco,
+  promocao,
+  precoOriginal,
+  novo,
   adicionarProduto,
 }) => {
   return (
@@ -16,9 +19,26 @@ const Produto = ({
       <div className="card">
         <img className="img-fluid" src={src} alt={alt} />
         <div className="card-body">
-          <h5 className="card-title fw-bold">{titulo}</h5>
+          <h5 className="card-title fw-bold">
+            {titulo}
+            {novo && (
+              <span className="badge text-bg-success ms-2">Novo</span>
+            )}
+            {promocao && (
+              <span className="badge text-bg-danger ms-2">Promoção</span>
+            )}
+          </h5>
           <p className="card-text">{descricao}</p>
-          <p className="fw-bold">{formatadorMoeda(preco)}</p>
+          {promocao ? (
+            <p className="fw-bold">
+              <span className="text-decoration-line-through me-2">
+                {formatadorMoeda(precoOriginal)}
+              </span>
+              {formatadorMoeda(preco)}
+            </p>
+          ) : (
+            <p className="fw-bold">{formatadorMoeda(preco)}</p>
+          )}
 
           <Botao
             variant="primary"

--- a/src/components/ProdutosNovos/index.jsx
+++ b/src/components/ProdutosNovos/index.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Produto from "@/components/Produtos/Produto";
+import produtos from "@/mocks/produtos.json";
+import Titulo from "@/components/Titulo";
+import { useCarrinhoContext } from "@/hooks/useCarrinhoContext";
+
+const ProdutosNovos = () => {
+  const { adicionarProduto } = useCarrinhoContext();
+  const produtosNovos = produtos.filter((produto) => produto.novo);
+
+  return (
+    <section role="produtos-novos" aria-label="Produtos novos">
+      <Titulo>Novidades</Titulo>
+      <div className="container row mx-auto">
+        {produtosNovos.map((produto) => (
+          <Produto
+            key={produto.id}
+            {...produto}
+            adicionarProduto={adicionarProduto}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProdutosNovos;

--- a/src/components/ProdutosPromocoes/index.jsx
+++ b/src/components/ProdutosPromocoes/index.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Produto from "@/components/Produtos/Produto";
+import produtos from "@/mocks/produtos.json";
+import Titulo from "@/components/Titulo";
+import { useCarrinhoContext } from "@/hooks/useCarrinhoContext";
+
+const ProdutosPromocoes = () => {
+  const { adicionarProduto } = useCarrinhoContext();
+  const produtosPromocao = produtos.filter((produto) => produto.promocao);
+
+  return (
+    <section role="produtos-promocao" aria-label="Produtos em promoção">
+      <Titulo>Promoções</Titulo>
+      <div className="container row mx-auto">
+        {produtosPromocao.map((produto) => (
+          <Produto
+            key={produto.id}
+            {...produto}
+            adicionarProduto={adicionarProduto}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProdutosPromocoes;

--- a/src/mocks/produtos.json
+++ b/src/mocks/produtos.json
@@ -5,7 +5,10 @@
     "alt": "Modelo masculo vestindo touca preta, blusa marrom e calça jeans, com uma parede cinza de fundo.",
     "titulo": "Camiseta conforto",
     "descricao": "Multicores e tamanhos. Tecido de algodão 100% fresquinho.",
-    "preco": 70.0
+    "preco": 70.0,
+    "promocao": false,
+    "precoOriginal": null,
+    "novo": true
   },
   {
     "id": 2,
@@ -13,7 +16,10 @@
     "alt": "Modelo feminina vestindo blusa marrom, calça bege, par de sapatos altos na cor branca, cordão e pulseira, em um ambiente aberto com chão de terra e matos secos.",
     "titulo": "Calça Alfaiataria",
     "descricao": "Modelo Wide Leg alfaiataria em linho. Uma peça para vida toda!",
-    "preco": 180.0
+    "preco": 180.0,
+    "promocao": true,
+    "precoOriginal": 200.0,
+    "novo": false
   },
   {
     "id": 3,
@@ -21,7 +27,10 @@
     "alt": "Foco nos pés de modelo usando par de tênis e meia na cor branca, e calça na cor preta, pisando em uma poça de água.",
     "titulo": "Tênis Chunky",
     "descricao": "Snicker casual com solado mais alto e modelagem robusta. Modelo unissex.",
-    "preco": 250.0
+    "preco": 250.0,
+    "promocao": false,
+    "precoOriginal": null,
+    "novo": false
   },
   {
     "id": 4,
@@ -29,7 +38,10 @@
     "alt": "Modelo masculino vestindo toca e calça na cor preta, jaqueta jeans azul, blusa branca e cordão dourado, em um fundo branco.",
     "titulo": "Jaqueta Jeans",
     "descricao": "Modelo unissex oversized com gola de camurça. Atemporal e autêntica!",
-    "preco": 150.0
+    "preco": 150.0,
+    "promocao": true,
+    "precoOriginal": 170.0,
+    "novo": false
   },
   {
     "id": 5,
@@ -37,7 +49,10 @@
     "alt": "Modelo masculino com blusa branca e um par de óculos de lentes transparentes arredondadas, utilizando um notebook, com um cachorro poodle branco no seu colo, e em um fundo branco.",
     "titulo": "Óculos Redondo",
     "descricao": "Armação metálica em grafite com lentes arredondadas. Sem erro!",
-    "preco": 120.0
+    "preco": 120.0,
+    "promocao": false,
+    "precoOriginal": null,
+    "novo": true
   },
   {
     "id": 6,
@@ -45,6 +60,9 @@
     "alt": "Cintura, pernas e pés de modelo feminina vestindo sobretudo de cor predominante bege com detalhes em tom vermelho e escuro, com calça e par de sapatos na cor preta, segurando bolsa na cor bege, com fundo de prédio.",
     "titulo": "Bolsa coringa",
     "descricao": "Bolsa camel em couro sintético de alta duração. Perfeita!",
-    "preco": 120.0
+    "preco": 120.0,
+    "promocao": false,
+    "precoOriginal": null,
+    "novo": false
   }
 ]

--- a/src/pages/Novidades.jsx
+++ b/src/pages/Novidades.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import BarraNavegacao from "@/components/BarraNavegacao";
+import Rodape from "@/components/Rodape";
+import CarrinhoSuspenso from "@/components/CarrinhoSuspenso";
+import ProdutosNovos from "@/components/ProdutosNovos";
+
+const Novidades = () => (
+  <>
+    <BarraNavegacao />
+    <CarrinhoSuspenso />
+    <main>
+      <ProdutosNovos />
+    </main>
+    <Rodape />
+  </>
+);
+
+export default Novidades;

--- a/src/pages/Promocoes.jsx
+++ b/src/pages/Promocoes.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import BarraNavegacao from "@/components/BarraNavegacao";
+import Rodape from "@/components/Rodape";
+import CarrinhoSuspenso from "@/components/CarrinhoSuspenso";
+import ProdutosPromocoes from "@/components/ProdutosPromocoes";
+
+const Promocoes = () => (
+  <>
+    <BarraNavegacao />
+    <CarrinhoSuspenso />
+    <main>
+      <ProdutosPromocoes />
+    </main>
+    <Rodape />
+  </>
+);
+
+export default Promocoes;


### PR DESCRIPTION
## Summary
- add metadata flags to product mock data
- show badges and struck-through prices for promotional items
- create filtered product listings and routes for promotions and new arrivals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_689619ed00208328a9e7b02859420a61