### PR TITLE
refactor: generic Produtos component with filters

### DIFF
--- a/src/components/Produtos/ProdutosNovos.jsx
+++ b/src/components/Produtos/ProdutosNovos.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import Produtos from ".";
+
+const ProdutosNovos = (props) => (
+  <Produtos titulo="Novidades" filtro={(p) => p.novo} {...props} />
+);
+
+export default ProdutosNovos;

--- a/src/components/Produtos/ProdutosPromocoes.jsx
+++ b/src/components/Produtos/ProdutosPromocoes.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import Produtos from ".";
+
+const ProdutosPromocoes = (props) => (
+  <Produtos titulo="Promoções" filtro={(p) => p.promocao} {...props} />
+);
+
+export default ProdutosPromocoes;

--- a/src/components/Produtos/index.jsx
+++ b/src/components/Produtos/index.jsx
@@ -1,16 +1,30 @@
-import React, { useContext } from "react";
+import React from "react";
 import Produto from "./Produto";
-import produtos from "@/mocks/produtos.json";
+import produtosMock from "@/mocks/produtos.json";
 import Titulo from "@/components/Titulo";
-import { useCarrinhoContext } from '@/hooks/useCarrinhoContext';
+import { useCarrinhoContext } from "@/hooks/useCarrinhoContext";
 
-const Produtos = () => {
+const filtrarProdutos = (produtos, filtro) => {
+  if (typeof filtro === "function") return produtos.filter(filtro);
+  if (filtro && typeof filtro === "object")
+    return produtos.filter((produto) =>
+      Object.entries(filtro).every(([chave, valor]) => produto[chave] === valor)
+    );
+  return produtos;
+};
+
+const Produtos = ({
+  titulo,
+  filtro,
+  produtos = produtosMock,
+}) => {
   const { adicionarProduto } = useCarrinhoContext();
+  const produtosFiltrados = filtrarProdutos(produtos, filtro);
   return (
-    <section role="produtos" aria-label="Produtos que estão bombando!">
-      <Titulo>Produtos que estão bombando!</Titulo>
+    <section role="produtos" aria-label={titulo}>
+      <Titulo>{titulo}</Titulo>
       <div className="container row mx-auto">
-        {produtos.map((produto) => (
+        {produtosFiltrados.map((produto) => (
           <Produto
             key={produto.id}
             {...produto}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -17,7 +17,7 @@ const Home = () => {
       <main>
         <Carrossel />
         <Categorias />
-        <Produtos/>
+        <Produtos titulo="Produtos que estão bombando!" filtro={() => true} />
         <Facilidades />
         <Novidades />
       </main>


### PR DESCRIPTION
## Summary
- refactor Produtos into generic list accepting title, filter and data
- wire Home to display Produtos with passthrough filter
- add ProdutosPromocoes and ProdutosNovos wrappers for common filters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot read config file: .eslintrc.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_689619ef4ff4832898bada7bcbfaadbe